### PR TITLE
SQL-2770: Update YamlTestCase to tolerate 'pipeline' as an input alias

### DIFF
--- a/test-generator/src/lib.rs
+++ b/test-generator/src/lib.rs
@@ -40,7 +40,7 @@ pub struct YamlTestCase<I, E, O> {
     pub description: String,
     pub skip_reason: Option<String>,
 
-    #[serde(alias = "query", alias = "test_definition")]
+    #[serde(alias = "query", alias = "test_definition", alias = "pipeline")]
     pub input: I,
 
     #[serde(flatten)]


### PR DESCRIPTION
This PR adds a convenient alias, `pipeline`, to the `YamlTestCase`'s `input` field. This is helpful for schema derivation tests where the "input" is named "pipeline". Instead of changing hundreds of files, I think this is the best way to approach this. We already include common aliases in this repo so this follows our existing paradigms.