### PR TITLE
SQL-2770: Add CARGO_NET_FIT_FETCH_WITH_CLI option to rust_util config

### DIFF
--- a/evergreen/configs/rust_util.yml
+++ b/evergreen/configs/rust_util.yml
@@ -21,7 +21,7 @@ variables:
       add_to_path:
         - ${cargo_bin}
       env:
-        CARGO_NET_GIT_FETCH_WITH_CLI: true
+        CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       binary: sh
 
 functions:


### PR DESCRIPTION
This PR adds the necessary env variable that enables our other projects to use this repo as a code dependency (since cargo fails to pull our private repo without this set).