### PR TITLE
SQL-2953: add versioning to tests

### DIFF
--- a/evergreen/configs/rust_util.yml
+++ b/evergreen/configs/rust_util.yml
@@ -92,6 +92,7 @@ functions:
         <<: *rust_subprocess_default_params
         include_expansions_in_env:
           - cargo_test_flags
+          - mongodb_version
           - description
         args:
           - ${script_dir}/run_rust_tests.sh

--- a/evergreen/scripts/run_rust_tests.sh
+++ b/evergreen/scripts/run_rust_tests.sh
@@ -3,4 +3,6 @@
 set -o errexit
 
 echo $description
+echo "mongodb version: $mongodb_version"
+export MONGODB_VERSION=$mongodb_version
 cargo test $cargo_test_flags


### PR DESCRIPTION
Ultimately the simplest approach I found was to:
1. take the version (already part of the test config) and pass it as a variable to the run rust test task
2. update the run rust test script to export this variable so the test generator in mongosql has access to this
3. have tests specify if there is a minimum or maximum server version the test is valid for, and if this option is specified, verify the underlying server version is in bounds.

I think this was the simplest way since we are round tripping from mongosql -> common test infra -> mongosql.

I will leave more detailed comments in the corresponding mongosql pr about how this is handled in practice, but for the sake of this pr, it is just important to know that the common test infra's responsibility is to add the server version to the env.

Here is a patch with the tests passing: https://spruce.mongodb.com/version/68dc46486dddaf000743eaf3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC