### PR TITLE
DEVPROD-34208: use DevProd ECR for container images instead of Artifactory

### DIFF
--- a/evergreen/configs/ssdlc_util.yml
+++ b/evergreen/configs/ssdlc_util.yml
@@ -148,6 +148,22 @@ functions:
           AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
           AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN
           EOF
+    - command: ec2.assume_role
+      display_name: Assume DevProd Platforms ECR readonly IAM role
+      params:
+        role_arn: ${devprod_platforms_ecr_readonly_role_arn}
+    - command: shell.exec
+      display_name: Log in to DevProd Platforms ECR
+      params:
+        silent: true
+        shell: bash
+        include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+        script: |
+          set -o errexit
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
 
   # Augments SBOM file and uploads to S3. Requires the working_dir and script_dir expansions to be set appropriately.
   #

--- a/evergreen/scripts/augment_sbom.sh
+++ b/evergreen/scripts/augment_sbom.sh
@@ -8,6 +8,6 @@ echo "SBOM_OUT_PATH = $sbom_out_path"
 echo "-- Augmenting SBOM Lite --"
 docker run -i --platform="linux/amd64" --rm -v "$PWD":/pwd \
   --env-file ./aws_vars.env \
-  artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:2.0 \
+  901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
   augment --repo $github_org/$github_repo --branch $branch_name --sbom-in /pwd/$sbom_in_path --sbom-out /pwd/$sbom_out_path --force
 echo "-------------------------------"


### PR DESCRIPTION
MongoDB Artifactory is deprecated. This updates the DevProd container image source to ECR instead of Artifactory.